### PR TITLE
Add ability to change value of configured env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,14 @@
 
 # VSCode Extension: Status Bar Env Var
 
-Display system environment variables that VSCode is running in the context of in the status bar.
+Display system environment variables in the VSCode status bar and overwrite them easily.
+
+## Limitations
 
 This extension only runs locally and not in remote environments. This means that when using a remote environment the environment variables displayed are those of the local machine running the VSCode UI and not those of the remote VSCode Server.
+
+Overwritten environmental variables are only applied to shell environmental variables, not the VSCode built in ${env} variable.
+To use the variables in tasks or launch configurations, use the built in shell variables.
 
 ## Install
 
@@ -12,4 +17,11 @@ https://marketplace.visualstudio.com/items?itemName=leighmcculloch.status-bar-en
 
 ## Usage
 
-In the settings specify a comma-separated list of environment variables that should be displayed in the status bar. The status bar will update immediately to show the variable name and value.
+In the settings specify a list of environment variables that should be displayed in the status bar. The status bar will update immediately to show the variable name and value.
+Each environmental variable can have an optional list of options to allow quick switching between preset values and a comment to clarify what it is used for. Following format is used:
+
+```
+NAME[option1, option2, ...]#comment
+```
+
+The value of each configured environmental variable can be overwritten by clicking on it's status bar item or launching the "Set value of a configured environmental variable" command.

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "properties": {
           "statusBarEnvVar.environmentVariableNames": {
             "type": "array",
-            "scope": "application",
+            "scope": "window",
             "title": "Environmental variables",
             "description": "List of environment variables to display in the status bar.",
             "items": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
             "description": "List of environment variables to display in the status bar.",
             "items": {
               "type": "string",
-              "format": "NAME[option1, option2]#comment",
+              "format": "NAME[option1, option2, ...]#comment",
               "description": "Name and optional options that can be selected as enum and optional comment to show on hover"
             }
           }

--- a/package.json
+++ b/package.json
@@ -3,9 +3,12 @@
   "displayName": "Status Bar Env Var",
   "description": "Display an environment variable value in the status bar.",
   "license": "MIT",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "author": "Leigh McCulloch",
   "publisher": "leighmcculloch",
+  "contributors": [
+    "Seppe Stas"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/leighmcculloch/vscode-extension-status-bar-env-var"
@@ -19,7 +22,7 @@
     "Other"
   ],
   "activationEvents": [
-    "*"
+    "onStartupFinished"
   ],
   "contributes": {
     "configuration": [
@@ -27,14 +30,24 @@
         "title": "Status Bar Env Var",
         "properties": {
           "statusBarEnvVar.environmentVariableNames": {
-            "type": "string",
-            "default": "DOCKER_HOST",
-            "description": "A comma-separated list of environment variables to display in the status bar.",
-            "scope": "application"
+            "type": "array",
+            "scope": "application",
+            "title": "Environmental variables",
+            "description": "List of environment variables to display in the status bar.",
+            "items": {
+              "type": "string",
+              "format": "NAME[option1, option2]#comment",
+              "description": "Name and optional options that can be selected as enum and optional comment to show on hover"
+            }
           }
         }
       }
-    ]
+    ],
+    "commands": [{
+      "command": "statusBarEnvVar.setEnvVarValue",
+      "shortTitle": "Set Env var value",
+      "title": "Set value of a configured environmental variable"
+    }]
   },
   "main": "./out/extension.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -15,9 +15,11 @@
   },
   "icon": "resources/icon.png",
   "engines": {
-    "vscode": "^1.55.0"
+    "vscode": "^1.65.0"
   },
-  "extensionKind": ["ui"],
+  "extensionKind": [
+    "ui"
+  ],
   "categories": [
     "Other"
   ],
@@ -43,11 +45,13 @@
         }
       }
     ],
-    "commands": [{
-      "command": "statusBarEnvVar.setEnvVarValue",
-      "shortTitle": "Set Env var value",
-      "title": "Set value of a configured environmental variable"
-    }]
+    "commands": [
+      {
+        "command": "statusBarEnvVar.setEnvVarValue",
+        "shortTitle": "Set Env var value",
+        "title": "Set value of a configured environmental variable"
+      }
+    ]
   },
   "main": "./out/extension.js",
   "scripts": {
@@ -60,7 +64,7 @@
     "@types/glob": "^7.1.3",
     "@types/mocha": "^8.0.4",
     "@types/node": "^12.11.7",
-    "@types/vscode": "^1.55.0",
+    "@types/vscode": "^1.65.0",
     "@typescript-eslint/eslint-plugin": "^4.14.1",
     "@typescript-eslint/parser": "^4.14.1",
     "eslint": "^7.19.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,35 +1,102 @@
 import * as vscode from 'vscode';
 
-const envVarNamesConfig = 'statusBarEnvVar.environmentVariableNames';
-
-let statusBarItem: vscode.StatusBarItem;
+const envVarNamesConfig = "statusBarEnvVar.environmentVariableNames";
+const commandName = "statusBarEnvVar.setEnvVarValue";
 
 export function activate({ subscriptions }: vscode.ExtensionContext) {
-	statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100);
-	subscriptions.push(statusBarItem);
-
+	var envVars: Map<string, {sbarItem: vscode.StatusBarItem,  options?: Array<string>}> = new Map();
 	subscriptions.push(vscode.workspace.onDidChangeConfiguration(e => {
 		if (e.affectsConfiguration(envVarNamesConfig)) {
-			updateStatusBarItem();
+			updateStatusBarItems(subscriptions, envVars);
 		}
 	}));
 
-	updateStatusBarItem();
+	subscriptions.push(vscode.commands.registerCommand(
+		commandName,
+		(envVarName?: string) => {
+			(async (): Promise<string | undefined> => {
+				if (!envVarName) {
+					envVarName = await vscode.window.showQuickPick(Array.from(envVars.keys()), {
+						title: "Select environmental variable name",
+						canPickMany: false
+					} as vscode.QuickPickOptions);
+				}
+				return envVarName;
+			})().then((envVarName?: string) => {
+				if (envVarName) {
+					var envVar = envVars.get(envVarName);
+					if (envVar) {
+						setEnvVar(envVarName, envVar.options).then(() => {
+							if (envVar) {
+								envVar.sbarItem.text = `${envVarName}=${process.env[envVarName as string]}`;
+							}
+						});
+					}
+				}
+			});
+		}
+	));
+
+	updateStatusBarItems(subscriptions, envVars);
 }
 
-function updateStatusBarItem() {
-	const envVarNamesList = vscode.workspace.getConfiguration().get(envVarNamesConfig) as string;
-	if (!envVarNamesList) {
+async function setEnvVar(envVarName: string, options?: Array<string>) {
+	const prompt = `Set ${envVarName} to`;
+	let value = options?
+		await vscode.window.showQuickPick(options, {
+			title: prompt,
+			canPickMany: false
+		} as vscode.QuickPickOptions) :
+		await vscode.window.showInputBox({
+			prompt: prompt,
+			value: process.env[envVarName]
+		});
+	
+	if (value) {
+		process.env[envVarName] = value;
+	}
+}
+
+function updateStatusBarItems(subscriptions: vscode.ExtensionContext["subscriptions"], envVars: Map<string, {sbarItem: vscode.StatusBarItem,  options?: Array<string>}>) {
+	if (envVars.size > 0) {
+		envVars.forEach((envVar) => {
+			envVar.sbarItem.dispose();
+		});
+		envVars.clear();
+	}
+	const envVarList = vscode.workspace.getConfiguration().get(envVarNamesConfig) as Array<string>;
+	if (!envVarList) {
 		return;
 	}
 
-	const envVarNames = envVarNamesList.split(",");
+	envVarList.forEach(envVar => {
+		let statusBarItem: vscode.StatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100);
+		let t: Array<string>;
+		
+		let options: Array<string> | undefined;
+		t = envVar.split("#");
 
-	statusBarItem.text = envVarNames
-		.map((n: string): string => `${n}=${process.env[n] || ""}`)
-		.join(" ");
+		statusBarItem.tooltip = (t.length > 1) ? t[1].trim() : "";
 
-	statusBarItem.show();
+		t = t[0].split("[");
+		options = (t.length > 1) ?
+			t[1].split("]")[0].trim().split(",").map((o: string): string => o.trim()):
+			undefined;
+
+		let envVarName: string = t[0].trim();
+		statusBarItem.text = `${envVarName}=${process.env[envVarName]}`;
+
+		
+		statusBarItem.command = {
+			command: commandName,
+			arguments: [envVarName, options, statusBarItem]
+		} as vscode.Command;
+
+		subscriptions.push(statusBarItem);
+		envVars.set(envVarName, {sbarItem: statusBarItem, options: options});
+
+		statusBarItem.show();
+	});
 }
 
 export function deactivate() { }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,25 +14,21 @@ export function activate({ subscriptions }: vscode.ExtensionContext) {
 	subscriptions.push(vscode.commands.registerCommand(
 		commandName,
 		(envVarName?: string) => {
-			(async (): Promise<string | undefined> => {
+			(async (): Promise<string> => {
 				if (!envVarName) {
 					envVarName = await vscode.window.showQuickPick(Array.from(envVars.keys()), {
 						title: "Select environmental variable name",
 						canPickMany: false
 					} as vscode.QuickPickOptions);
 				}
-				return envVarName;
-			})().then((envVarName?: string) => {
-				if (envVarName) {
-					var envVar = envVars.get(envVarName);
-					if (envVar) {
-						setEnvVar(envVarName, envVar.options).then(() => {
-							if (envVar) {
-								envVar.sbarItem.text = `${envVarName}=${process.env[envVarName as string]}`;
-							}
-						});
-					}
-				}
+				return Promise.resolve(envVarName as string);
+			})().then((envVarName: string) => {
+				var envVar = envVars.get(envVarName);
+					setEnvVar(envVarName, envVar?.options).then(() => {
+						if (envVar) {
+							envVar.sbarItem.text = `${envVarName}=${process.env[envVarName as string]}`;
+						}
+					});
 			});
 		}
 	));
@@ -72,10 +68,9 @@ function updateStatusBarItems(subscriptions: vscode.ExtensionContext["subscripti
 	envVarList.forEach(envVar => {
 		let statusBarItem: vscode.StatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100);
 		let t: Array<string>;
-		
+
 		let options: Array<string> | undefined;
 		t = envVar.split("#");
-
 		statusBarItem.tooltip = (t.length > 1) ? t[1].trim() : "";
 
 		t = t[0].split("[");
@@ -86,7 +81,6 @@ function updateStatusBarItems(subscriptions: vscode.ExtensionContext["subscripti
 		let envVarName: string = t[0].trim();
 		statusBarItem.text = `${envVarName}=${process.env[envVarName]}`;
 
-		
 		statusBarItem.command = {
 			command: commandName,
 			arguments: [envVarName, options, statusBarItem]


### PR DESCRIPTION
Hi @leighmcculloch,

Thanks for your plugin, it did most of what I want it to do, but it was missing a couple of features for me:

- The ability to quickly change the value of configured environmental variables
- The ability to configure environmental variables on a per-workspace basis

I added these features in this PR. It also adds the option to document configured environmental variables:

![image](https://user-images.githubusercontent.com/1408377/158178465-c7622f64-9c64-4f7b-98b3-943b4b4739b1.png)

My main use-case is a "target architecture/BSP" selection and "target programmer" selection.

![image](https://user-images.githubusercontent.com/1408377/158178852-8b48736e-e7f6-4992-a349-c70bb79c39b2.png)
![image](https://user-images.githubusercontent.com/1408377/158178777-0d1a4d24-13bb-443b-b187-1b0a315c0f3c.png)

(don't worry, these are internal IPs, not IPs on the public internet).

I think the use of environmental variables for configuration is a lot more flexible than the more domain specific plugins.

I understand this greatly changes the functionality of the plugin, so I would understand if you prefer not to merge. Would it be ok if I keep the fork?